### PR TITLE
Syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,6 +150,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['diff', 'makefile', 'bash', 'json']
       },
     }),
   plugins: [require.resolve('docusaurus-lunr-search')],


### PR DESCRIPTION
## Overview

Add language support for diff, makefile, bash and json to prism syntax highlighter.